### PR TITLE
Nuclei.Communication: Notification registration and unregistration should not throw

### DIFF
--- a/src/nuclei.communication/Interaction/Transport/NotificationEventAddMethodInterceptor.cs
+++ b/src/nuclei.communication/Interaction/Transport/NotificationEventAddMethodInterceptor.cs
@@ -10,6 +10,7 @@ using System.Globalization;
 using System.Reflection;
 using Castle.DynamicProxy;
 using Nuclei.Communication.Interaction.Transport.Messages;
+using Nuclei.Communication.Protocol;
 using Nuclei.Diagnostics;
 using Nuclei.Diagnostics.Logging;
 
@@ -98,34 +99,45 @@ namespace Nuclei.Communication.Interaction.Transport
                     "Invoking {0}",
                     MethodToText(invocation.Method)));
 
-            try
+            var methodToInvoke = invocation.Method.Name;
+            var eventName = methodToInvoke.Substring(MethodPrefix.Length);
+            var eventInfo = m_InterfaceType.GetEvent(eventName);
+            var eventId = NotificationId.Create(eventInfo);
+
+            var handler = invocation.Arguments[0] as Delegate;
+            var proxy = invocation.Proxy as NotificationSetProxy;
+
+            if (!proxy.HasSubscribers(eventId))
             {
-                var methodToInvoke = invocation.Method.Name;
-                var eventName = methodToInvoke.Substring(MethodPrefix.Length);
-                var eventInfo = m_InterfaceType.GetEvent(eventName);
-                var eventId = NotificationId.Create(eventInfo);
-
-                var handler = invocation.Arguments[0] as Delegate;
-                var proxy = invocation.Proxy as NotificationSetProxy;
-
-                if (!proxy.HasSubscribers(eventId))
-                { 
+                try
+                {
                     m_TransmitRegistration(eventId);
                 }
+                catch (EndpointNotContactableException e)
+                {
+                    m_Diagnostics.Log(
+                        LevelToLog.Error,
+                        CommunicationConstants.DefaultLogTextPrefix,
+                        string.Format(
+                            CultureInfo.InvariantCulture,
+                            "Error while registering for a notification {0}. Error was: {1}",
+                            MethodToText(invocation.Method),
+                            e));
+                }
+                catch (FailedToSendMessageException e)
+                {
+                    m_Diagnostics.Log(
+                        LevelToLog.Error,
+                        CommunicationConstants.DefaultLogTextPrefix,
+                        string.Format(
+                            CultureInfo.InvariantCulture,
+                            "Error while registering for a notification {0}. Error was: {1}",
+                            MethodToText(invocation.Method),
+                            e));
+                }
+            }
 
-                proxy.AddToEvent(eventId, handler);
-            }
-            catch (Exception e)
-            {
-                m_Diagnostics.Log(
-                    LevelToLog.Error,
-                    CommunicationConstants.DefaultLogTextPrefix,
-                    string.Format(
-                        CultureInfo.InvariantCulture,
-                        "Error while registering for a notification {0}. Error was: {1}",
-                        MethodToText(invocation.Method),
-                        e));
-            }
+            proxy.AddToEvent(eventId, handler);
         }
     }
 }


### PR DESCRIPTION
When registering or unregistrering from a notification it is possible for that action to fail if the network connection is not there for some reason. This results in exceptions being thrown in actions that do not normally (in normal .NET code) throw exceptions. It would probably be better to swallow these exceptions (log them).
