### PR TITLE
Updating GitReleaseNotes to the latest version (0.4.0)

### DIFF
--- a/Build.GatherReleaseNotes.msbuild
+++ b/Build.GatherReleaseNotes.msbuild
@@ -75,10 +75,10 @@
             <Output TaskParameter="Path" PropertyName="PathGitReleaseNotesExe" />
         </FindToolFromPackages>
         
-        <Exec Command="&quot;$(PathGitReleaseNotesExe)&quot; /I GitHub /R $(GitHubUserName)/nuclei /U $(GitHubUserName) /T $(GitHubToken) /V $(VersionSemantic) /O &quot;$(FileReleaseNotesShort)&quot;"
+        <Exec Command="&quot;$(PathGitReleaseNotesExe)&quot; /IssueTracker GitHub /Repo $(GitHubUserName)/nuclei /Username $(GitHubUserName) /Token $(GitHubToken) /Version $(VersionSemantic) /OutputFile &quot;$(FileReleaseNotesShort)&quot;"
               WorkingDirectory="$(DirWorkspace)" />
         
-        <Exec Command="&quot;$(PathGitReleaseNotesExe)&quot; /I GitHub /R $(GitHubUserName)/nuclei /U $(GitHubUserName) /T $(GitHubToken) /F all /V $(VersionSemantic) /O &quot;$(FileReleaseNotesFull)&quot;"
+        <Exec Command="&quot;$(PathGitReleaseNotesExe)&quot; /IssueTracker GitHub /Repo $(GitHubUserName)/nuclei /Username $(GitHubUserName) /Token $(GitHubToken) /AllTags /Version $(VersionSemantic) /OutputFile &quot;$(FileReleaseNotesFull)&quot;"
               WorkingDirectory="$(DirWorkspace)" />
     </Target>
  </Project>

--- a/packages.config
+++ b/packages.config
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
     <package id="GitHubFlowVersion" version="1.3.2" />
-    <package id="GitReleaseNotes" version="0.2.1" />
+    <package id="GitReleaseNotes" version="0.4.0" />
     <package id="NUnit.Runners" version="2.6.2" />
     <package id="opencover" version="4.5.1923" />
     <package id="reportgenerator" version="1.9.1.0" />


### PR DESCRIPTION
Updated to the latest version of GitReleaseNotes (0.4.0).

fixes #34
